### PR TITLE
feat: product-images

### DIFF
--- a/app/Livewire/Admin/Products/ProductForm.php
+++ b/app/Livewire/Admin/Products/ProductForm.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin\Products;
 
 use App\Models\Category;
 use App\Models\Product;
+use App\Traits\FileUploader;
 use App\Traits\LivewireToast;
 use Carbon\Carbon;
 use Livewire\Component;
@@ -16,6 +17,7 @@ class ProductForm extends Component
 {
     use LivewireToast;
     use WithFileUploads;
+    use FileUploader;
 
     public $product;
 
@@ -37,7 +39,7 @@ class ProductForm extends Component
 
     public $extended_price;
 
-    public $discount = 0;
+    public $discount = 10;
 
     public $is_free = false;
 
@@ -288,24 +290,32 @@ class ProductForm extends Component
 
         // Media and files
         if ($this->image) {
-            // Delete old image if it exists
-            if ($this->existing_image) {
-                Storage::disk('uploads')->delete($this->existing_image);
-            }
-            $imagePath = Storage::disk('uploads')->putFile('products/images', $this->image);
+            $imagePath = $this->handleImage(
+                $this->image,
+                'products/images',
+                $this->existing_image,
+                856,
+                550
+            );
             $product->image = $imagePath;
         }
-
+        // handles thumbnail upload
         if ($this->thumbnail) {
-            // Delete old thumbnail if it exists
-            if ($this->existing_thumbnail) {
-                Storage::disk('uploads')->delete($this->existing_thumbnail);
-            }
-            $thumbnailPath = Storage::disk('uploads')->putFile('products/thumbnails', $this->thumbnail);
+            $thumbnailPath = $this->handleImage(
+                $this->thumbnail,
+                'products/thumbnails',
+                $this->existing_thumbnail,
+                590,
+                300
+            );
             $product->thumbnail = $thumbnailPath;
         }
 
         if ($this->file_path && $this->download_type === 'file') {
+            // Delete old file if it exists
+            if ($this->existing_file) {
+                Storage::disk('uploads')->delete($this->existing_file);
+            }
             $filePath = $this->file_path->store('products/files', 'uploads');
             $product->file_path = $filePath;
         }

--- a/app/Livewire/Admin/Products/ProductForm.php
+++ b/app/Livewire/Admin/Products/ProductForm.php
@@ -10,7 +10,6 @@ use Carbon\Carbon;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 use Purify;
-use Storage;
 use Str;
 
 class ProductForm extends Component
@@ -312,11 +311,11 @@ class ProductForm extends Component
         }
 
         if ($this->file_path && $this->download_type === 'file') {
-            // Delete old file if it exists
-            if ($this->existing_file) {
-                Storage::disk('uploads')->delete($this->existing_file);
-            }
-            $filePath = $this->file_path->store('products/files', 'uploads');
+            $filePath = $this->handleFile(
+                $this->file_path,
+                'products/files',
+                $this->existing_file
+            );
             $product->file_path = $filePath;
         }
 

--- a/app/Livewire/Admin/Products/ProductForm.php
+++ b/app/Livewire/Admin/Products/ProductForm.php
@@ -15,9 +15,9 @@ use Str;
 
 class ProductForm extends Component
 {
+    use FileUploader;
     use LivewireToast;
     use WithFileUploads;
-    use FileUploader;
 
     public $product;
 

--- a/app/Livewire/Admin/Products/ProductForm.php
+++ b/app/Livewire/Admin/Products/ProductForm.php
@@ -305,8 +305,8 @@ class ProductForm extends Component
                 $this->thumbnail,
                 'products/thumbnails',
                 $this->existing_thumbnail,
-                590,
-                300
+                290,
+                160
             );
             $product->thumbnail = $thumbnailPath;
         }

--- a/app/Livewire/Product/Details.php
+++ b/app/Livewire/Product/Details.php
@@ -26,7 +26,7 @@ class Details extends Component
     {
         $cacheKey = 'related_products_'.$this->product->id;
 
-        return Cache::remember($cacheKey, now()->addHours(1), function () {
+        return Cache::remember($cacheKey, now()->addMinutes(30), function () {
             return Product::where('category_id', $this->product->category_id)
                 ->where('id', '!=', $this->product->id)
                 ->inRandomOrder()

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -106,4 +106,10 @@ class Product extends Model
     {
         return $this->sales_count + $this->sales_boost;
     }
+
+    public function getScreenshotImagesAttribute()
+    {
+        // add the image to the screenshot array and return
+        return array_merge([$this->image], $this->screenshots);
+    }
 }

--- a/app/Traits/FileUploader.php
+++ b/app/Traits/FileUploader.php
@@ -44,7 +44,7 @@ trait FileUploader
 
         // Resize logic
         if ($width && $height) {
-            $image->scale($width, $height);
+            $image->resize($width, $height);
         } elseif ($width) {
             $image->scaleDown(width: $width);
         } elseif ($height) {
@@ -54,7 +54,7 @@ trait FileUploader
         // Format-specific encoding
         $encodedImage = match ($extension) {
             'jpg', 'jpeg' => $image->toJpeg(quality: $quality),
-            'png' => $image->toPng(compression: $quality),
+            'png' => $image->toPng(),
             'webp' => $image->toWebp(quality: $quality),
             'avif' => $image->toAvif(quality: $quality),
             'heic' => $image->toHeic(quality: $quality),

--- a/app/Traits/FileUploader.php
+++ b/app/Traits/FileUploader.php
@@ -63,7 +63,14 @@ trait FileUploader
         };
 
         // Store the file
-        Storage::disk($disk)->put($fullPath, $encodedImage);
+        try {
+            Storage::disk($disk)->put($fullPath, $encodedImage);
+        } catch (\Exception $e) {
+            // Log the error or handle it appropriately
+            \Log::error("Failed to store image: {$e->getMessage()}");
+
+            return null;
+        }
 
         return $fullPath;
     }

--- a/app/Traits/FileUploader.php
+++ b/app/Traits/FileUploader.php
@@ -2,11 +2,10 @@
 
 namespace App\Traits;
 
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\Laravel\Facades\Image;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Intervention\Image\Interfaces\EncodedImageInterface;
+use Intervention\Image\Laravel\Facades\Image;
 
 trait FileUploader
 {
@@ -23,7 +22,7 @@ trait FileUploader
         ?string $format = null,
         string $disk = 'uploads'
     ): ?string {
-        if (!$file) {
+        if (! $file) {
             return null;
         }
 
@@ -36,8 +35,8 @@ trait FileUploader
         $extension = $format ? strtolower($format) : $file->getClientOriginalExtension();
 
         // Create a unique filename
-        $filename = Str::random(35) . '-' . time() . '.' . $extension;
-        $fullPath = $path . '/' . $filename;
+        $filename = Str::random(35).'-'.time().'.'.$extension;
+        $fullPath = $path.'/'.$filename;
 
         // Read the image using Intervention
         $image = Image::read($file);
@@ -72,10 +71,10 @@ trait FileUploader
     /**
      * Store a regular file (non-image) and optionally delete the old one.
      *
-     * @param UploadedFile|null $file The uploaded file
-     * @param string $path Storage path
-     * @param string|null $oldFile Old file path to delete
-     * @param string $disk Filesystem disk (default: 'uploads')
+     * @param  UploadedFile|null  $file  The uploaded file
+     * @param  string  $path  Storage path
+     * @param  string|null  $oldFile  Old file path to delete
+     * @param  string  $disk  Filesystem disk (default: 'uploads')
      * @return string|null Path to the stored file
      */
     public function handleFile(
@@ -84,7 +83,7 @@ trait FileUploader
         ?string $oldFile = null,
         string $disk = 'uploads'
     ): ?string {
-        if (!$file) {
+        if (! $file) {
             return null;
         }
 

--- a/app/Traits/FileUploader.php
+++ b/app/Traits/FileUploader.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Laravel\Facades\Image;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+use Intervention\Image\Interfaces\EncodedImageInterface;
+
+trait FileUploader
+{
+    /**
+     * Store and optionally resize an image.
+     */
+    public function handleImage(
+        ?UploadedFile $file,
+        string $path,
+        ?string $oldFile = null,
+        ?int $width = null,
+        ?int $height = null,
+        int $quality = 90,
+        ?string $format = null,
+        string $disk = 'uploads'
+    ): ?string {
+        if (!$file) {
+            return null;
+        }
+
+        // Delete the old file if it exists
+        if ($oldFile && Storage::disk($disk)->exists($oldFile)) {
+            Storage::disk($disk)->delete($oldFile);
+        }
+
+        // Determine the final extension
+        $extension = $format ? strtolower($format) : $file->getClientOriginalExtension();
+
+        // Create a unique filename
+        $filename = Str::random(35) . '-' . time() . '.' . $extension;
+        $fullPath = $path . '/' . $filename;
+
+        // Read the image using Intervention
+        $image = Image::read($file);
+
+        // Resize logic
+        if ($width && $height) {
+            $image->scale($width, $height);
+        } elseif ($width) {
+            $image->scaleDown(width: $width);
+        } elseif ($height) {
+            $image->scaleDown(height: $height);
+        }
+
+        // Format-specific encoding
+        $encodedImage = match ($extension) {
+            'jpg', 'jpeg' => $image->toJpeg(quality: $quality),
+            'png' => $image->toPng(compression: $quality),
+            'webp' => $image->toWebp(quality: $quality),
+            'avif' => $image->toAvif(quality: $quality),
+            'heic' => $image->toHeic(quality: $quality),
+            'gif' => $image->toGif(),
+            'bmp' => $image->toBitmap(),
+            default => $image->toJpeg(quality: $quality),
+        };
+
+        // Store the file
+        Storage::disk($disk)->put($fullPath, $encodedImage);
+
+        return $fullPath;
+    }
+
+    /**
+     * Store a regular file (non-image) and optionally delete the old one.
+     *
+     * @param UploadedFile|null $file The uploaded file
+     * @param string $path Storage path
+     * @param string|null $oldFile Old file path to delete
+     * @param string $disk Filesystem disk (default: 'uploads')
+     * @return string|null Path to the stored file
+     */
+    public function handleFile(
+        ?UploadedFile $file,
+        string $path,
+        ?string $oldFile = null,
+        string $disk = 'uploads'
+    ): ?string {
+        if (!$file) {
+            return null;
+        }
+
+        if ($oldFile && Storage::disk($disk)->exists($oldFile)) {
+            Storage::disk($disk)->delete($oldFile);
+        }
+
+        return $file->store($path, $disk);
+    }
+}

--- a/config/image.php
+++ b/config/image.php
@@ -42,5 +42,5 @@ return [
         'decodeAnimation' => true,
         'blendingColor' => 'ffffff',
         'strip' => false,
-    ]
+    ],
 ];

--- a/config/image.php
+++ b/config/image.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image Driver
+    |--------------------------------------------------------------------------
+    |
+    | Intervention Image supports “GD Library” and “Imagick” to process images
+    | internally. Depending on your PHP setup, you can choose one of them.
+    |
+    | Included options:
+    |   - \Intervention\Image\Drivers\Gd\Driver::class
+    |   - \Intervention\Image\Drivers\Imagick\Driver::class
+    |
+    */
+
+    'driver' => \Intervention\Image\Drivers\Gd\Driver::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Configuration Options
+    |--------------------------------------------------------------------------
+    |
+    | These options control the behavior of Intervention Image.
+    |
+    | - "autoOrientation" controls whether an imported image should be
+    |    automatically rotated according to any existing Exif data.
+    |
+    | - "decodeAnimation" decides whether a possibly animated image is
+    |    decoded as such or whether the animation is discarded.
+    |
+    | - "blendingColor" Defines the default blending color.
+    |
+    | - "strip" controls if meta data like exif tags should be removed when
+    |    encoding images.
+    */
+
+    'options' => [
+        'autoOrientation' => true,
+        'decodeAnimation' => true,
+        'blendingColor' => 'ffffff',
+        'strip' => false,
+    ]
+];

--- a/resources/views/livewire/product/details.blade.php
+++ b/resources/views/livewire/product/details.blade.php
@@ -141,10 +141,10 @@
 
                                     <a href="javascript:void(0)" class="screenshot-btn btn btn-white pill px-sm-5"
                                         data-images='[
-                                        @foreach ($product->screenshots as $screenshot)
+                                        @foreach ($product->screenshot_images as $screenshot)
                                             "{{ my_asset($screenshot) }}"@if (!$loop->last), @endif @endforeach
                                         ]'>
-                                        Screenshot
+                                        Screenshots
                                     </a>
 
 

--- a/resources/views/partials/product/related.blade.php
+++ b/resources/views/partials/product/related.blade.php
@@ -1,7 +1,7 @@
 <div class="product-item shadow-sm overlay-none">
     <div class="product-item__thumb d-flex max-h-unset">
         <a href="{{ route('products.view', $relatedProduct->slug) }}" wire:navigate class="link w-100">
-            <img src="{{ my_asset($relatedProduct->image ?? 'products/default.jpg') }}" alt="" class="cover-img" style="min-height: 130px">
+            <img src="{{ my_asset($relatedProduct->thumbnail ?? 'products/default.jpg') }}" alt="" class="cover-img" style="min-height: 130px">
         </a>
     </div>
     <div class="product-item__content">


### PR DESCRIPTION
- Reduced thumbnail dimensions in ProductForm.
- Shortened related product cache duration.
- Improved image resizing efficiency.
- Used `resize` instead of `scale` for images.
- Updated related products image path.


- **New Features**
  - Added support for advanced image and file uploads, including automatic resizing and format options.
  - Main product image is now included with product screenshots for a more comprehensive gallery view.

- **Improvements**
  - Default discount for new products increased from 0 to 10.
  - Related product images now display thumbnails instead of main images.
  - Related products cache duration reduced to 30 minutes for fresher recommendations.
  - Product details page now displays all screenshots, including the main image, and updates button text to "Screenshots".

- **Configuration**
  - Introduced a new configuration for image processing, allowing customization of image handling settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new trait for improved file and image upload handling, including support for image resizing and format selection.
  - Introduced a configuration file for customizable image processing settings.
  - Product details now display both the main image and screenshots together.

- **Improvements**
  - Changed the default discount value for products from 0 to 10.
  - Related product thumbnails now use the dedicated thumbnail image for better visual consistency.
  - The related products cache duration was reduced from 1 hour to 30 minutes.
  - Updated product details view to display "Screenshots" and include all relevant images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->