### PR TITLE
feat(product): add sales count and boost fields

### DIFF
--- a/app/Livewire/Admin/Products/ProductForm.php
+++ b/app/Livewire/Admin/Products/ProductForm.php
@@ -112,8 +112,8 @@ class ProductForm extends Component
         'publish_date' => 'nullable|date',
         'short_description' => 'nullable|string',
         'description' => 'required|string|min:10',
-        'sales_count' => 'nullable|integer',
-        'sales_boost' => 'nullable|integer',
+        'sales_count' => 'nullable|integer|min:0',
+        'sales_boost' => 'nullable|integer|min:0',
     ];
 
     public function mount($id = null)

--- a/app/Livewire/Admin/Products/ProductForm.php
+++ b/app/Livewire/Admin/Products/ProductForm.php
@@ -74,6 +74,10 @@ class ProductForm extends Component
 
     public $publish_date;
 
+    public $sales_count;
+
+    public $sales_boost;
+
     // Screenshots array
     public $screenshots = [];
 
@@ -108,6 +112,8 @@ class ProductForm extends Component
         'publish_date' => 'nullable|date',
         'short_description' => 'nullable|string',
         'description' => 'required|string|min:10',
+        'sales_count' => 'nullable|integer',
+        'sales_boost' => 'nullable|integer',
     ];
 
     public function mount($id = null)
@@ -145,6 +151,8 @@ class ProductForm extends Component
         $this->download_link = $product->download_link;
         $this->download_type = $product->download_type;
         $this->demo_url = $product->demo_url;
+        $this->sales_count = $product->sales_count;
+        $this->sales_boost = $product->sales_boost;
 
         $this->featured = $product->featured;
         $this->tags = $product->tags ?? [];
@@ -286,6 +294,8 @@ class ProductForm extends Component
         $product->extended_price = $this->extended_price;
         $product->discount = $this->discount;
         $product->is_free = $this->is_free;
+        $product->sales_boost = $this->sales_boost;
+        $product->sales_count = $this->sales_count;
 
         // Media and files
         if ($this->image) {

--- a/resources/views/livewire/admin/products/product-form.blade.php
+++ b/resources/views/livewire/admin/products/product-form.blade.php
@@ -208,6 +208,29 @@
                         </div>
                     </div>
                 @endif
+                {{-- sales --}}
+                <div class="row">
+                    <div class=" col-sm-6">
+                        <div class="form-group mb-3">
+                            <label for="sales_count" class="form-label">Sales Count</label>
+                            <input type="number" class="common-input form-control @error('sales_count') is-invalid @enderror"
+                                wire:model="sales_count" id="sales_count">
+                            @error('sales_count')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="form-group mb-3">
+                            <label for="sales_boost" class="form-label">Sales Boost</label>
+                            <input type="number" class="common-input form-control @error('sales_boost') is-invalid @enderror"
+                                wire:model="sales_boost" id="sales_boost">
+                            @error('sales_boost')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
- Added sales_count and sales_boost fields to ProductForm.
- Updated validation rules.
- Added input fields to the view.
- Updated database migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added "Sales Count" and "Sales Boost" fields to the product form in the admin panel, allowing you to view and edit these sales-related values directly.
- **Bug Fixes**
  - Improved validation and error handling for the new sales fields to ensure accurate data entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->